### PR TITLE
Grant release job correct permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI Pipeline
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, fix/*, feature/*]
     tags: ["v*"]
   pull_request:
     branches: [main]
@@ -126,6 +126,8 @@ jobs:
     name: Create Release
     needs: [test, build]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: startsWith(github.ref, 'refs/tags/v')
 
     steps:


### PR DESCRIPTION
## Description
Not specifically granting write permissions to the release job results in the upload of release artifacts failing with a 403.

## Type of Change
Please delete options that are not relevant:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI/CD improvements

## Changes Made
- [x] Added content write permissions for release job
